### PR TITLE
Force color output and split output into lines

### DIFF
--- a/lib/gulp-helper-view.coffee
+++ b/lib/gulp-helper-view.coffee
@@ -47,8 +47,9 @@ class GulpHelperView extends View
     gulpHelper.scrollTop(gulpHelper[0].scrollHeight)
 
   gulpOut: (output) =>
-    stream = converter.toHtml(output);
-    atom.workspaceView.find('.gulp-helper .panel-body').append "<div class='text-highighted'>#{stream}</div>"
+    for line in output.split("\n")
+      stream = converter.toHtml(line);
+      atom.workspaceView.find('.gulp-helper .panel-body').append "<div class='text-highighted'>#{stream}</div>"
     @setScroll()
 
   gulpErr: (code) =>


### PR DESCRIPTION
Passes the `--color` option to gulp so it always outputs colour even if it can't detect support. Also splits the output into lines to fix a case I was encountering where `gulpOut` would receive multiple lines at once, putting them all into one line in the panel.
