### PR TITLE
Remove deprecated seletor

### DIFF
--- a/keymaps/gulp-helper.cson
+++ b/keymaps/gulp-helper.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'.atom-text-editor':
   'ctrl-alt-g': 'gulp-helper:toggle'


### PR DESCRIPTION
As the Atom 1.0 API has been announced, this pull request closes the warning the guld-helper project.

Ref: http://blog.atom.io/2015/01/15/announcing-the-atom-1-api.html