### PR TITLE
Multiple root folders

### DIFF
--- a/lib/gulp-helper-view.coffee
+++ b/lib/gulp-helper-view.coffee
@@ -56,7 +56,7 @@ class GulpHelperView extends View
     gulpHelper.scrollTop(gulpHelper[0].scrollHeight)
 
   gulpOut: (output, projectPath) =>
-    for line in output.split("\n")
+    for line in output.split("\n").filter((lineRaw) -> lineRaw isnt '')
       stream = converter.toHtml(line);
       atom.workspaceView.find('.gulp-helper .panel-body').append "<div class='text-highighted'><span class='folder-name'>#{projectPath}</span> #{stream}</div>"
     @setScroll()

--- a/lib/gulp-helper-view.coffee
+++ b/lib/gulp-helper-view.coffee
@@ -6,7 +6,7 @@ module.exports =
 class GulpHelperView extends View
   processes = {}
   command = if process.platform == 'win32' then 'gulp' else '/usr/local/bin/gulp'
-  args = ['--color', 'watch']
+  args = ['watch', '--color']
   @content: ->
     @div class: "gulp-helper tool-panel panel-bottom", =>
       @div class: "panel-heading affix", 'Gulp Output'

--- a/lib/gulp-helper-view.coffee
+++ b/lib/gulp-helper-view.coffee
@@ -32,7 +32,7 @@ class GulpHelperView extends View
   runGulp: ->
     if atom.project.getPath()
       atom.workspaceView.find('.gulp-helper .panel-body').html('')
-      command = if process.platform = 'win32' then 'gulp' else '/usr/local/bin/gulp'
+      command = if process.platform == 'win32' then 'gulp' else '/usr/local/bin/gulp'
       args = ['--color', 'watch']
       options = {
           cwd: atom.project.getPath()

--- a/stylesheets/gulp-helper.less
+++ b/stylesheets/gulp-helper.less
@@ -15,7 +15,9 @@
     div {
       margin: 5px;
     }
-
+    .folder-name {
+      font-weight: 900;
+    }
     .text-highighted {
       color: @text-color;
     }


### PR DESCRIPTION
Atom now supports multiple root folders, and therefore getProjectPath is deprecated. This PR includes support for getProjectPaths as well as running a Gulp process for each path returned.

I've tested that gulp is successfully started and stopped for each path with this new code when gulp-helper is toggled on and off.

Would be great to land this in apm asap @kenwheeler now that Atom has shipped the multi root folder feature to everyone.