### PR TITLE
Fix keybindings

### DIFF
--- a/keymaps/gulp-helper.cson
+++ b/keymaps/gulp-helper.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.atom-text-editor':
+'atom-workspace':
   'ctrl-alt-g': 'gulp-helper:toggle'

--- a/lib/gulp-helper-view.coffee
+++ b/lib/gulp-helper-view.coffee
@@ -32,7 +32,7 @@ class GulpHelperView extends View
   runGulp: ->
     if atom.project.getPath()
       atom.workspaceView.find('.gulp-helper .panel-body').html('')
-      command = if process.platform = 'win32' then 'gulp' else '/usr/local/bin/gulp'
+      command = if process.platform == 'win32' then 'gulp' else '/usr/local/bin/gulp'
       args = ['--color', 'watch']
       options = {
           cwd: atom.project.getPath()


### PR DESCRIPTION
The keybinding in the source was .atom-text-editor which isn't valid. The valid version of this would be atom-text-editor, since it is an element, not a class (looks like this issue was created by @brunosabot).

However, surely this package's keybinding should apply anywhere in Atom, since gulp watch is not dependent on the current file. The context is the whole project, therefore this PR amends the selector to be global.

Apologies for including the original gulp process path fix PR's commit in this PR - I shouldn't have put that original commit in my master branch! Hopefully that won't be an issue.