### PR TITLE
Fixing #23 by adding 'path' requirement to gulp-helper-view.coffee

### DIFF
--- a/lib/gulp-helper-view.coffee
+++ b/lib/gulp-helper-view.coffee
@@ -1,6 +1,8 @@
 {View} = require 'atom-space-pen-views'
 {BufferedProcess} = require 'atom'
 Convert = require 'ansi-to-html'
+path = path ? require 'path'
+
 converter = new Convert()
 module.exports =
 class GulpHelperView extends View


### PR DESCRIPTION
Not sure why there are not others (besides @imperez and I see this issue).
